### PR TITLE
feat(Cart): add Apple Pay via imperative SDK API

### DIFF
--- a/RozetkaPay.Example.UIKit/Config/Config.swift
+++ b/RozetkaPay.Example.UIKit/Config/Config.swift
@@ -12,4 +12,5 @@ struct Config {
     static let exampleCallbackUrl = "https://example.com/callback"
     static let decimalSeparator: String = "."
     static let buttonCornerRadius: CGFloat = 16
+    static let applePayButtonHeight: CGFloat = 50
 }

--- a/RozetkaPay.Example.UIKit/Config/Credentials.swift
+++ b/RozetkaPay.Example.UIKit/Config/Credentials.swift
@@ -73,10 +73,10 @@ struct Credentials {
     
     //MARK: - Production
     private struct Production: EnvironmentCredentials {
-        let WIDGET_KEY = "7zFsk43VTYaDZoF0iA7FLKl6l0Cj+6uMxiZmKS1guUt0XKYjSKvAOkUXFihVe60k"
-        
-        let LOGIN = "a6a29002-dc68-4918-bc5d-51a6094b14a8"
-        let PASSWORD = "XChz3J8qrr"
+        let WIDGET_KEY = "Bujzvr5EQd+cP9QeimLcMDjwtqVBXUSQxhs2ACpzYaR2mDmBlHPpLp8y5skjVrYg"
+
+        let LOGIN = "06e8f3be-be44-41df-9c3f-d41e8a62dc30"
+        let PASSWORD = "VE50V0ZMY0RsRTdzeFl1QzJQdXpFQ3d1"
         
         var AUTH_TOKEN: String {
             Credentials.makeAuthToken(login: LOGIN, password: PASSWORD)

--- a/RozetkaPay.Example.UIKit/Extensions/UIViewControllerExtensions.swift
+++ b/RozetkaPay.Example.UIKit/Extensions/UIViewControllerExtensions.swift
@@ -9,9 +9,7 @@ import UIKit
 
 extension UIViewController {
     func showCustomAlert(item: AlertItem) {
-        guard let windowScene = UIApplication.shared.connectedScenes
-                .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-              let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+        guard let keyWindow = UIApplication.shared.alertHostWindow else {
             print("⚠️ Couldn't find key window.")
             return
         }
@@ -54,5 +52,17 @@ extension UIViewController {
             alertView.alpha = 1
             alertView.transform = .identity
         }
+    }
+}
+
+//MARK: - Private
+private extension UIApplication {
+
+    var alertHostWindow: UIWindow? {
+        let scenes = connectedScenes.compactMap { $0 as? UIWindowScene }
+        let foregroundScenes = scenes.filter { $0.activationState == .foregroundActive }
+        let windows = (foregroundScenes.isEmpty ? scenes : foregroundScenes).flatMap { $0.windows }
+
+        return windows.first(where: { $0.isKeyWindow }) ?? windows.first
     }
 }

--- a/RozetkaPay.Example.UIKit/View/BatchCartViewController.swift
+++ b/RozetkaPay.Example.UIKit/View/BatchCartViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import RozetkaPaySDK
 import OSLog
 import SwiftUI
+import PassKit
 
 class BatchCartViewController: UIViewController {
     
@@ -149,20 +150,43 @@ class BatchCartViewController: UIViewController {
         checkBox.translatesAutoresizingMaskIntoConstraints = false
         return checkBox
     }()
-    
+
+    /// The host draws its own Apple Pay button and starts the payment through
+    /// `RozetkaPaySdk.payByApplePay` — the SDK renders no form of its own here.
+    private lazy var applePayButton: PKPaymentButton = {
+        let button = PKPaymentButton(paymentButtonType: .plain, paymentButtonStyle: .automatic)
+        button.cornerRadius = Config.buttonCornerRadius
+        button.translatesAutoresizingMaskIntoConstraints = false
+        let action = UIAction { [weak self] _ in
+            self?.didTapApplePayButton()
+        }
+        button.addAction(action, for: .primaryActionTriggered)
+        return button
+    }()
+
+    private lazy var loaderView: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.color = .systemGreen
+        indicator.hidesWhenStopped = true
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+
     private lazy var stackBottom: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [
             stackLable,
             checkBox,
-            checkoutButton
+            checkoutButton,
+            applePayButton
         ])
         stack.axis = .vertical
         stack.alignment = .fill
         stack.spacing = 20
+        stack.setCustomSpacing(8, after: checkoutButton)
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
-    
+
     //MARK: - Inits
     init(
         externalId: String? = nil,
@@ -203,28 +227,39 @@ private extension BatchCartViewController {
             action: #selector(didTapBackButton)
         )
         view.backgroundColor = UIColor.systemBackground
-        
+
         view.addSubview(mainStack)
-        
+        view.addSubview(loaderView)
+
+        // Apple Pay is unusable on this device — collapse the row instead of
+        // showing a button that cannot start a payment.
+        applePayButton.isHidden = !RozetkaPaySdk.isApplePayAvailable(
+            config: viewModel.testApplePayConfig
+        )
+
         setupLayouts()
     }
-    
+
     func setupLayouts() {
         NSLayoutConstraint.activate([
-            
+
             mainStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,constant: 20),
             mainStack.leftAnchor.constraint(equalTo: view.leftAnchor),
             mainStack.rightAnchor.constraint(equalTo: view.rightAnchor),
             mainStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
-            
+
             titleLable.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20),
             titleLable.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -20),
-            
+
             stackBottom.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20),
             stackBottom.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -20),
-            
+
             checkoutButton.heightAnchor.constraint(equalToConstant: 52),
-            stackLable.widthAnchor.constraint(equalTo: stackBottom.widthAnchor)
+            applePayButton.heightAnchor.constraint(equalToConstant: Config.applePayButtonHeight),
+            stackLable.widthAnchor.constraint(equalTo: stackBottom.widthAnchor),
+
+            loaderView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loaderView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
     
@@ -272,10 +307,41 @@ private extension BatchCartViewController {
         present(hostingController, animated: true, completion: nil)
     }
     
+    func didTapApplePayButton() {
+        setLoading(true)
+
+        RozetkaPaySdk.payByApplePay(
+            batchParameters: BatchApplePayFormParameters(
+                client: viewModel.clientParameters,
+                applePayConfig: viewModel.testApplePayConfig,
+                amountParameters: AmountParameters(
+                    amount: viewModel.totalNetAmountInCoins,
+                    tax: viewModel.totalVatAmountInCoins,
+                    total: viewModel.totalAmountInCoins,
+                    currencyCode: Config.defaultCurrencyCode
+                ),
+                externalId: viewModel.externalId,
+                callbackUrl: Config.exampleCallbackUrl,
+                orders: viewModel.orders.mapToBatchOrder()
+            ),
+            presentingViewController: self,
+            onResultCallback: { [weak self] result in
+                self?.setLoading(false)
+                self?.handleResult(result)
+            }
+        )
+    }
+
+    func setLoading(_ isLoading: Bool) {
+        isLoading ? loaderView.startAnimating() : loaderView.stopAnimating()
+        applePayButton.isEnabled = !isLoading
+        checkoutButton.isEnabled = !isLoading
+    }
+
     func handleCheckBoxChanged(_ selected: Bool) {
         viewModel.isNeedToUseTokenizedCard = selected
     }
-    
+
     func handleResult(_ result: BatchPaymentResult) {
         let alertItem: AlertItem
         

--- a/RozetkaPay.Example.UIKit/View/CartViewController.swift
+++ b/RozetkaPay.Example.UIKit/View/CartViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import RozetkaPaySDK
 import OSLog
 import SwiftUI
+import PassKit
 
 class CartViewController: UIViewController {
     
@@ -145,20 +146,43 @@ class CartViewController: UIViewController {
         checkBox.translatesAutoresizingMaskIntoConstraints = false
         return checkBox
     }()
-    
+
+    /// The host draws its own Apple Pay button and starts the payment through
+    /// `RozetkaPaySdk.payByApplePay` — the SDK renders no form of its own here.
+    private lazy var applePayButton: PKPaymentButton = {
+        let button = PKPaymentButton(paymentButtonType: .plain, paymentButtonStyle: .automatic)
+        button.cornerRadius = Config.buttonCornerRadius
+        button.translatesAutoresizingMaskIntoConstraints = false
+        let action = UIAction { [weak self] _ in
+            self?.didTapApplePayButton()
+        }
+        button.addAction(action, for: .primaryActionTriggered)
+        return button
+    }()
+
+    private lazy var loaderView: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.color = .systemGreen
+        indicator.hidesWhenStopped = true
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+
     private lazy var stackBottom: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [
             stackLable,
             checkBox,
-            checkoutButton
+            checkoutButton,
+            applePayButton
         ])
         stack.axis = .vertical
         stack.alignment = .fill
         stack.spacing = 20
+        stack.setCustomSpacing(8, after: checkoutButton)
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
-    
+
     //MARK: - Inits
     init(
         orderId: String? = nil,
@@ -199,28 +223,39 @@ private extension CartViewController {
             action: #selector(didTapBackButton)
         )
         view.backgroundColor = UIColor.systemBackground
-        
+
         view.addSubview(mainStack)
-        
+        view.addSubview(loaderView)
+
+        // Apple Pay is unusable on this device — collapse the row instead of
+        // showing a button that cannot start a payment.
+        applePayButton.isHidden = !RozetkaPaySdk.isApplePayAvailable(
+            config: viewModel.testApplePayConfig
+        )
+
         setupLayouts()
     }
-    
+
     func setupLayouts() {
         NSLayoutConstraint.activate([
-            
+
             mainStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,constant: 20),
             mainStack.leftAnchor.constraint(equalTo: view.leftAnchor),
             mainStack.rightAnchor.constraint(equalTo: view.rightAnchor),
             mainStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
-            
+
             titleLable.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20),
             titleLable.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -20),
-            
+
             stackBottom.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20),
             stackBottom.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -20),
-            
+
             checkoutButton.heightAnchor.constraint(equalToConstant: 52),
-            stackLable.widthAnchor.constraint(equalTo: stackBottom.widthAnchor)
+            applePayButton.heightAnchor.constraint(equalToConstant: Config.applePayButtonHeight),
+            stackLable.widthAnchor.constraint(equalTo: stackBottom.widthAnchor),
+
+            loaderView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loaderView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
     
@@ -268,10 +303,40 @@ private extension CartViewController {
         present(hostingController, animated: true, completion: nil)
     }
     
+    func didTapApplePayButton() {
+        setLoading(true)
+
+        RozetkaPaySdk.payByApplePay(
+            parameters: ApplePayFormParameters(
+                client: viewModel.clientParameters,
+                applePayConfig: viewModel.testApplePayConfig,
+                amountParameters: AmountParameters(
+                    amount: viewModel.totalNetAmountInCoins,
+                    tax: viewModel.totalVatAmountInCoins,
+                    total: viewModel.totalAmountInCoins,
+                    currencyCode: Config.defaultCurrencyCode
+                ),
+                externalId: viewModel.orderId,
+                callbackUrl: Config.exampleCallbackUrl
+            ),
+            presentingViewController: self,
+            onResultCallback: { [weak self] result in
+                self?.setLoading(false)
+                self?.handleResult(result)
+            }
+        )
+    }
+
+    func setLoading(_ isLoading: Bool) {
+        isLoading ? loaderView.startAnimating() : loaderView.stopAnimating()
+        applePayButton.isEnabled = !isLoading
+        checkoutButton.isEnabled = !isLoading
+    }
+
     func handleCheckBoxChanged(_ selected: Bool) {
         viewModel.isNeedToUseTokenizedCard = selected
     }
-    
+
     func handleResult(_ result: PaymentResult) {
         let alertItem: AlertItem
         


### PR DESCRIPTION
Both cart screens now offer Apple Pay next to the existing checkout button. The new SDK entry points (`RozetkaPaySdk.payByApplePay` / `isApplePayAvailable`) are built for hosts that draw their own button, so UIKit no longer has to wrap the SwiftUI `ApplePayFormView` in a hosting controller.

- Draw a native `PKPaymentButton` in `stackBottom` and start the payment imperatively — single payment in `CartViewController`, batch in `BatchCartViewController`
- Hide the button when `isApplePayAvailable` is false so the stack collapses the row instead of showing an unusable button
- Drive the loader from the host: the imperative flow emits no UI state, so it runs from the tap until the terminal result arrives
- Fix `showCustomAlert` silently dropping alerts: a result delivered right after the Apple Pay sheet is torn down can find the app with no foreground-active scene and no key window, so the window lookup now treats both as preferences with a fallback